### PR TITLE
Add list component, typed variable and synthesizer logic for these.

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -21,7 +21,7 @@ if [ $? != 0 ] ; then usage ; fi
 
 eval set -- "$OPTS"
 
-JOBS="`cat /proc/cpuinfo | grep processor | wc -l`"
+JOBS="$([[ $(uname) = 'Darwin' ]] && sysctl -n hw.logicalcpu_max || lscpu -p | egrep -v '^#' | wc -l)"
 
 WITH_LOGGING=""
 MAKE_Z3_AT=""

--- a/src/Logic.ml
+++ b/src/Logic.ml
@@ -13,7 +13,7 @@ let all_supported =
    in List.iter ~f:(fun component -> String.Table.set table ~key:component.name ~data:component)
         [{
            name = "LIA" ;
-           components = Th_Bool.components @ Th_LIA.components ;
+           components = Th_Bool.components @ Th_LIA.components @ Th_List.components;
            conflict_group_size_multiplier = 1
          } ; {
            name = "NIA" ;

--- a/src/TestGen.ml
+++ b/src/TestGen.ml
@@ -1,11 +1,49 @@
 open Core
 open Core.Quickcheck
 
-let for_type (t : Type.t) : Value.t Generator.t =
+let (--) lower upper =
+  For_int.gen_incl lower upper
+
+let weighted lower upper =
+  let open Quickcheck.Generator in
+  weighted_union
+  (List.map (List.range lower (upper + 1)) ~f:(fun x -> (float_of_int x, singleton x)))
+
+let small_int = -4 -- 4
+let small_weighted_nat = weighted 0 5
+
+type setting = {
+  list_dim : (int Generator.t) list;
+  int_range : int Generator.t;
+}
+
+let default_setting = {
+  list_dim = [];
+  int_range = (-4096 -- 4095);
+}
+
+let rec for_type ?(s : setting = default_setting) (t : Type.t) : Value.t Generator.t =
   let open Generator in
   match t with
   (* Use Small Ints, within 2^12: *)
-  | Type.INT -> (For_int.gen_incl (-4096) 4095) >>= fun i -> singleton (Value.Int i)
+  | Type.INT -> s.int_range >>= fun i -> singleton (Value.Int i)
   (* Full range of Int:
   | Type.INT -> Int.gen >>= fun i -> singleton (Value.Int i) *)
   | Type.BOOL -> Bool.gen >>= fun b -> singleton (Value.Bool b)
+  | Type.LIST t ->
+    let (dim_hd, dim_tl) = match s.list_dim with
+      | h :: t -> (h, t)
+      | [] -> (small_weighted_nat, []) in
+    let elem = for_type ~s:{s with list_dim=dim_tl} t in
+    dim_hd
+    >>= fun len -> List.gen_with_length len elem
+    >>= fun res -> singleton (Value.List (res, t))
+  | _ -> failwith "Not implemented"
+
+let repeat ~n ?seed genlist =
+  let open Generator in
+  let gen = all genlist in
+  let random_seed = match seed with
+    | None -> `Nondeterministic
+    | Some seed -> `Deterministic seed in
+  random_value (list_with_length n gen) ~seed:random_seed

--- a/src/Th_List.ml
+++ b/src/Th_List.ml
@@ -1,0 +1,81 @@
+open Base
+
+open Expr
+
+let vempty = Value.List ([], Type.TVAR "x")
+
+let components = [
+  {
+    name = "list-len";
+    codomain = Type.INT;
+    domain = [Type.LIST (Type.TVAR "t")];
+    is_argument_valid = (function | [Const (Value.List _)] -> false | _ -> true) ; 
+    evaluate = (function [@warning "-8"] [Value.List (x, _)] -> Value.Int (List.length x));
+    to_string = (fun [@warning "-8"] [a] -> "(len " ^ a ^ ")");
+    global_constraints = (fun _ -> [])
+  } ;
+  {
+    name = "list-empty?";
+    codomain = Type.BOOL;
+    domain = [Type.LIST (Type.TVAR "t")];
+    is_argument_valid = (function | [Const (Value.List _)] -> false | _ -> true) ; 
+    evaluate = (function [@warning "-8"] [Value.List (x,_)] -> Value.Bool (List.length x = 0));
+    to_string = (fun [@warning "-8"] [a] -> "(" ^ a ^ " = [])");
+    global_constraints = (fun _ -> [])
+  } ;
+  {
+    name = "list-rev";
+    codomain = Type.LIST (Type.TVAR "t");
+    domain = [Type.LIST (Type.TVAR "t")];
+    is_argument_valid = (function | [Const (Value.List _)] -> false | _ -> true) ; 
+    evaluate = (function [@warning "-8"] [Value.List (x,t)] -> Value.List (List.rev x, t));
+    to_string = (fun [@warning "-8"] [a] -> "(rev " ^ a ^ ")");
+    global_constraints = (fun _ -> [])
+  } ;
+  {
+    name = "list-cons";
+    codomain = Type.LIST (Type.TVAR "t");
+    domain = [Type.TVAR "t"; Type.LIST (Type.TVAR "t")];
+    is_argument_valid = (function | _ -> true);
+    evaluate = (function [@warning "-8"] [x; Value.List (xs,t)] -> Value.List (x::xs, t));
+    to_string = (fun [@warning "-8"] [a; b] -> "(" ^ a ^ " :: " ^ b ^ ")");
+    global_constraints = (fun _ -> [])
+  } ;
+  {
+    name = "list-hd";
+    codomain = Type.TVAR "t";
+    domain = [Type.LIST (Type.TVAR "t")];
+    is_argument_valid = (function | _ -> true);
+    evaluate = (function [@warning "-8"] [Value.List (x::_, _)] -> x);
+    to_string = (fun [@warning "-8"] [a] -> "(hd " ^ a ^ ")");
+    global_constraints = (fun _ -> [])
+  } ;
+  {
+    name = "list-tl";
+    codomain = Type.TVAR "t";
+    domain = [Type.LIST (Type.TVAR "t")];
+    is_argument_valid = (function | _ -> true);
+    evaluate = (function [@warning "-8"] [Value.List (_::xs, t)] -> Value.List (xs, t));
+    to_string = (fun [@warning "-8"] [a] -> "(tl " ^ a ^ ")");
+    global_constraints = (fun _ -> [])
+  } ;
+  {
+    name = "list-eq";
+    codomain = Type.BOOL;
+    domain = [Type.LIST (Type.TVAR "t"); Type.LIST (Type.TVAR "t")];
+    is_argument_valid = (function | _ -> true);
+    evaluate = (function [@warning "-8"] 
+      [Value.List (a, _); Value.List (b, _)] -> Value.Bool (List.equal ~equal:Value.equal a b));
+    to_string = (fun [@warning "-8"] [a; b] -> "(eq " ^ a ^ " " ^ b ^ ")");
+    global_constraints = (fun _ -> [])
+  }
+]
+
+(* We use Th_List with only Th_LIA for now. *)
+(* let all_components = Th_LIA.components @ components
+
+let () = Stdio.print_endline "Initialization of Meta-components Begins"
+let forall_components = List.filter_map ~f:Th_Quant.meta_transform all_components
+let () = Stdio.print_endline "Initialization Done"
+
+let all_components = all_components @ Th_Quant.all_components @ forall_components *)

--- a/src/Type.ml
+++ b/src/Type.ml
@@ -1,8 +1,12 @@
+open Base
+
 open Exceptions
 
 type t = INT
        | BOOL
-       [@@deriving sexp]
+       | LIST of t
+       | TVAR of string
+       [@@deriving compare,sexp]
 
 let of_string (s : string) : t =
   match s with
@@ -10,7 +14,19 @@ let of_string (s : string) : t =
   | "Bool" -> BOOL
   | _ -> raise (Parse_Exn ("Could not parse type `" ^ s ^ "`."))
 
-let to_string (t : t) : string =
+let rec to_string (t : t) : string =
   match t with
   | INT -> "Int"
   | BOOL -> "Bool"
+  | LIST t -> "List(" ^ to_string t ^ ")"
+  | TVAR t -> "TVar(" ^ t ^ ")"
+
+let is_list (t : t) : bool =
+  match t with
+  | LIST _ -> true
+  | _ -> false
+
+let is_tvar (t : t) : bool =
+  match t with
+  | TVAR _ -> true
+  | _ -> false

--- a/src/Unify.ml
+++ b/src/Unify.ml
@@ -1,0 +1,65 @@
+open Base
+
+open Type
+
+(* Unification algorithm referenced from http://www.cs.cornell.edu/courses/cs3110/2011fa/supplemental/lec26-type-inference/type-inference.htm *)
+type substitution = (string * Type.t) list 
+
+exception UnifyError of string
+
+let collect_varname t = 
+  let rec collect t acc = match t with 
+  | TVAR i -> i :: acc 
+  | LIST t1 -> collect t1 acc
+  | _ -> acc in 
+  collect t []
+
+let collect_varnames t = 
+  let l = List.map ~f:collect_varname t in
+  let l = List.concat l in
+  List.dedup_and_sort ~compare:String.compare l
+
+let rename names terms = 
+  let table = Hashtbl.create (module String) in 
+  List.iter names ~f:(fun name -> Hashtbl.set table ~key:name ~data:());
+  let rec fresh s suffix = 
+    let name = s ^ Int.to_string suffix in
+    match Hashtbl.mem table name with 
+    | true -> fresh s (suffix + 1)
+    | false -> name in 
+  let rec do_rename t = match t with 
+    | TVAR s -> TVAR (fresh s 0)
+    | LIST t1 -> LIST (do_rename t1)
+    | _ -> t in 
+  List.map ~f:do_rename terms
+
+let rec occurs svar t = match t with 
+  | TVAR s -> String.equal svar s
+  | LIST t1 -> occurs svar t1
+  | _ -> false
+
+let rec subst (id,sub) t = match t with 
+  | TVAR x -> if String.equal x id then sub else t
+  | LIST t1 -> LIST (subst (id,sub) t1)
+  | _ -> t
+
+let apply subs typ = 
+  List.fold_right ~f:(fun s t -> subst s t) ~init:typ subs
+
+let rec unify_one (t1 : Type.t) (t2 : Type.t) : substitution = match (t1, t2) with 
+  | TVAR x, TVAR y -> if String.equal x y then [] else [(x, t2)]
+  | TVAR x, t2 -> if occurs x t2 then raise (UnifyError "cannot unify: circularity") else [(x, t2)]
+  | t1, TVAR x -> if occurs x t1 then raise (UnifyError "cannot unify: circularity") else [(x, t1)]
+  | LIST x, LIST y -> unify_one x y 
+  | INT, INT | BOOL, BOOL -> []
+  | _ -> raise (UnifyError "cannot unify: different types")
+
+let rec unify (t1 : Type.t list) (t2 : Type.t list) : substitution = match (t1, t2) with 
+  | (x :: tx, y :: ty) -> 
+    let s2 = unify tx ty in
+    let s1 = unify_one (apply s2 x) (apply s2 y) in begin 
+      match s1 with [el] -> el :: s2 | _ -> s2
+    end
+  | _ -> []
+
+let unifiable t1 t2 = try ignore (unify t1 t2); true with _ -> false

--- a/src/Value.ml
+++ b/src/Value.ml
@@ -2,9 +2,12 @@ open Base
 
 open Exceptions
 
+open Utils
+
 module T = struct
   type t = Int of int
          | Bool of bool
+         | List of t list * Type.t
          [@@deriving compare,sexp]
 end
 
@@ -15,12 +18,14 @@ let typeof (v : t) : Type.t =
   match v with
   | Int _  -> Type.INT
   | Bool _ -> Type.BOOL
+  | List (_,t) -> Type.LIST t
 [@@inline always]
 
-let to_string (v : t) : string =
+let rec to_string (v : t) : string =
   match v with
   | Int i  -> Int.to_string i
   | Bool b -> Bool.to_string b
+  | List (l, _) -> "(" ^ List.to_string_map l ~sep:" " ~f:to_string ^ ")"
 [@@inline always]
 
 let of_string (s : string) : t =

--- a/test/Runner.ml
+++ b/test/Runner.ml
@@ -6,4 +6,6 @@ let () =
          ; "Test_VPIE", (Test_VPIE.all ~zpath)
          ; "Test_ZProc", (Test_ZProc.all ~zpath)
          ; "Test_Synthesizer", Test_Synthesizer.all
+         ; "Test_Unification", Test_Unify.all
+         ; "Test_Zhouheng", Test_Zhouheng.all
          ])

--- a/test/Test_Unify.ml
+++ b/test/Test_Unify.ml
@@ -1,0 +1,41 @@
+open Base
+open LoopInvGen
+
+open Type
+open Unify
+open Utils
+
+
+let unification_test () = 
+  let domain1 = [TVAR "x"; LIST (TVAR "x")] in 
+  let codomain1 = TVAR "x" in 
+  let domain2 = [INT; LIST INT] in 
+  let s = unify domain1 domain2 in 
+  let codomain2 = apply s codomain1 in 
+  Alcotest.(check bool) "identical" true (Poly.equal codomain2 INT);
+
+  let domain1 = [TVAR "x"; LIST (TVAR "x")] in 
+  let domain2 = [LIST INT; LIST INT] in 
+  let s = unifiable domain1 domain2 in 
+  Alcotest.(check bool) "identical" false s;
+
+  let domain1 = [TVAR "x"; TVAR "x"] in 
+  let domain2 = [LIST BOOL; LIST INT] in 
+  let s = unifiable domain1 domain2 in 
+  Alcotest.(check bool) "identical" false s;
+
+  let domain1 = [TVAR "x"; TVAR "y"] in 
+  let domain2 = [BOOL; LIST INT] in 
+  let s = unifiable domain1 domain2 in 
+  Alcotest.(check bool) "identical" true s;
+
+  let names = ["x"; "y"] in 
+  let domains = [TVAR "x"; LIST (TVAR "y")] in 
+  let res = rename names domains in 
+  Alcotest.(check (list string)) "identical" 
+    (List.map ~f:Type.to_string [TVAR "x0"; LIST (TVAR "y0")]) 
+    (List.map ~f:Type.to_string res)
+
+let all = [
+  "Unification Test",    `Quick, unification_test ;
+]

--- a/test/Test_Zhouheng.ml
+++ b/test/Test_Zhouheng.ml
@@ -1,0 +1,57 @@
+open Base
+open LoopInvGen
+open PIE
+open TestGen
+
+let len_job = Job.create
+    ~f:(fun [@warning "-8"] [ Value.List(l,_) ] -> Value.Bool (List.length l < 2))
+    ~args:([ "x", Type.LIST Type.INT ])
+    ~post:(fun inp res -> match inp , res with
+        | [ Value.List (_, _) ], Ok (Value.Bool y) -> y
+        | _ -> false)
+    (List.map [[]; [1]; [2;2]; [3]; [4;1;0]]
+       ~f:(fun l ->
+           let vi = List.map l ~f:(fun i -> Value.Int i) in
+           [Value.List (vi, Type.INT)]))
+
+let list_eq_job = Job.create
+    ~f:(fun [@warning "-8"] [l]  -> l)
+    ~args:([ "x", Type.LIST Type.INT ])
+    ~post:(fun inp res -> match inp , res with
+        | _, Ok v -> Value.equal v (Value.List ([Value.Int 0; Value.Int 0; Value.Int 0], Type.INT) )
+        | _ -> false)
+    (repeat ~n:1000
+       [for_type (Type.LIST Type.INT) ~s:{list_dim = [2--5]; int_range = 0--1} ])
+
+let test_gen_test () = 
+    let s = {list_dim = [weighted 1 5]; int_range = (-1)--1} in
+    let l = repeat ~n:100 ~seed:"test" [for_type ~s (Type.LIST Type.INT)] in
+    (* let printl l = List.iter l 
+        ~f:(fun x -> Stdio.print_endline (Value.to_string (List.hd_exn x))) in
+    printl gen; *)
+    (* This should be weighted so more 5s then 4s and so on *)
+    let countlen len =
+      List.count l ~f:(fun l1 -> match l1 with
+          | [Value.List (l,_)] -> List.length l = len
+          | _ -> false) in
+    Alcotest.(check bool) "identical" true
+        (List.for_all (List.init 4 ~f:(fun n -> countlen (n+2) > countlen (n+1))) ~f:(fun x -> x))
+
+let len_test () =
+  let res = cnf_opt_to_desc (learnPreCond len_job) in
+  Alcotest.(check string) "identical" "(<= (len x) 1)" res
+
+let list_eq_test () =
+  let res = cnf_opt_to_desc (learnPreCond list_eq_job) in
+  Alcotest.(check string) "identical" "(eq (0 :: (0 :: (0 :: ()))) x)" res
+
+let mk_silent_test job () =
+  let res = cnf_opt_to_desc (learnPreCond job) in
+  Stdio.print_endline ("result = " ^ res);
+  Alcotest.(check bool) "identical" true true
+
+let all = [
+  "List.len <= 2", `Quick, len_test;
+  "List.equal [0; 0; 0]", `Quick, list_eq_test;
+  "TestGen works", `Quick, test_gen_test;
+]


### PR DESCRIPTION
I have added typed lists and integrated it into the synthesizer. To accommodate polymorphism, type variables are introduced to enable parametric types in components, which comes with unification and variable renaming. 
Also, I integrated most of the list.ml tests in PIE, and all of them are able to infer the precondition correctly with our meta-components added back. Now, empowered by typed lists, meta-components can be automatically manufactured from existing 'base' components. 