### PR TITLE
Support for map transformers for components

### DIFF
--- a/src/ArrayComponents.ml
+++ b/src/ArrayComponents.ml
@@ -10,47 +10,45 @@ let all = [
   {
     name = "select";
     codomain = Type.TVAR "b";
-    domain = [Type.ARRAY (Type.TVAR "a", Type.TVAR "b"); Type.TVAR "a"];
+    domain = Type.[ARRAY (TVAR "a", TVAR "b"); TVAR "a"];
     is_argument_valid = (function
                          | [FCall (comp, [a ; k1 ; _]) ; k2]
                            when String.equal comp.name "store"
                            -> k1 =/= k2
                          | _ -> true);
     evaluate = (fun [@warning "-8"]
-                [Value.Array (_, _, elems, default_val) ; key]
+                Value.[Array (_, _, elems, default_val) ; key]
                 -> match List.Assoc.find elems ~equal:Value.equal key with
                    | None -> default_val
                    | Some value -> value);
     to_string = (fun [@warning "-8"] [a ; b] -> "(select " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
-  }
-  ;
+  } ;
   {
     name = "store";
-    codomain = Type.ARRAY (Type.TVAR "a", Type.TVAR "b");
-    domain = [Type.ARRAY (Type.TVAR "a", Type.TVAR "b"); Type.TVAR "a"; Type.TVAR "b"];
+    codomain = Type.(ARRAY (TVAR "a", TVAR "b"));
+    domain = Type.[ARRAY (TVAR "a", TVAR "b"); TVAR "a"; TVAR "b"];
     is_argument_valid = (function
                          | _ -> true);
     evaluate = (fun [@warning "-8"]
-                [Value.Array (key_type, val_type, elems, default_val) ; key ; value]
+                Value.[Array (key_type, val_type, elems, default_val) ; key ; value]
                 -> Value.Array (key_type, val_type, (key, value)::elems, default_val));
     to_string = (fun [@warning "-8"] [a ; b ; c] -> "(store " ^ a ^ " " ^ b ^ " " ^ c ^ ")");
     global_constraints = (fun _ -> [])
-  }
-  ;
+  } ;
   {
     name = "equal";
     codomain = Type.BOOL;
-    domain = [Type.ARRAY (Type.TVAR "a", Type.TVAR "b"); Type.ARRAY (Type.TVAR "a", Type.TVAR "b")];
+    domain = Type.[ARRAY (TVAR "a", TVAR "b"); ARRAY (TVAR "a", TVAR "b")];
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y)
                          | _ -> true);
     evaluate = (fun [@warning "-8"]
-                [ Value.Array (a_key_type, a_val_type, a_elems, a_default_val)
-                ; Value.Array (b_key_type, b_val_type, b_elems, b_default_val) ]
+                Value.[ Array (a_key_type, a_val_type, a_elems, a_default_val)
+                      ; Array (b_key_type, b_val_type, b_elems, b_default_val) ]
                 -> Value.Bool (
-                     (Poly.equal a_key_type b_key_type) &&
-                     (Poly.equal a_val_type b_val_type) &&
+                     (Type.equal a_key_type b_key_type) &&
+                     (Type.equal a_val_type b_val_type) &&
                      (Value.equal a_default_val b_default_val) &&
                      (List.equal (Tuple.T2.equal ~eq1:Value.equal ~eq2:Value.equal)
                                  (normalize a_elems)

--- a/src/ArrayComponents.ml
+++ b/src/ArrayComponents.ml
@@ -9,50 +9,50 @@ let normalize = List.dedup_and_stable_sort ~which_to_keep:`First
 let all = [
   {
     name = "select";
-    codomain = Type.TVAR "b";
-    domain = Type.[ARRAY (TVAR "a", TVAR "b"); TVAR "a"];
+    codomain = Type.TVAR "T2";
+    domain = Type.[ARRAY (TVAR "T1", TVAR "T2"); TVAR "T1"];
     is_argument_valid = (function
                          | [FCall (comp, [a ; k1 ; _]) ; k2]
                            when String.equal comp.name "store"
                            -> k1 =/= k2
                          | _ -> true);
-    evaluate = (fun [@warning "-8"]
-                Value.[Array (_, _, elems, default_val) ; key]
-                -> match List.Assoc.find elems ~equal:Value.equal key with
-                   | None -> default_val
-                   | Some value -> value);
+    evaluate = Value.(fun [@warning "-8"]
+                      [Array (_, _, elems, default_val) ; key]
+                      -> match List.Assoc.find elems ~equal:Value.equal key with
+                         | None -> default_val
+                         | Some value -> value);
     to_string = (fun [@warning "-8"] [a ; b] -> "(select " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   } ;
   {
     name = "store";
-    codomain = Type.(ARRAY (TVAR "a", TVAR "b"));
-    domain = Type.[ARRAY (TVAR "a", TVAR "b"); TVAR "a"; TVAR "b"];
+    codomain = Type.(ARRAY (TVAR "T1", TVAR "T2"));
+    domain = Type.[ARRAY (TVAR "T1", TVAR "T2"); TVAR "T1"; TVAR "T2"];
     is_argument_valid = (function
                          | _ -> true);
-    evaluate = (fun [@warning "-8"]
-                Value.[Array (key_type, val_type, elems, default_val) ; key ; value]
-                -> Value.Array (key_type, val_type, (key, value)::elems, default_val));
+    evaluate = Value.(fun [@warning "-8"]
+                      [Array (key_type, val_type, elems, default_val) ; key ; value]
+                      -> Array (key_type, val_type, (key, value)::elems, default_val));
     to_string = (fun [@warning "-8"] [a ; b ; c] -> "(store " ^ a ^ " " ^ b ^ " " ^ c ^ ")");
     global_constraints = (fun _ -> [])
   } ;
   {
     name = "equal";
     codomain = Type.BOOL;
-    domain = Type.[ARRAY (TVAR "a", TVAR "b"); ARRAY (TVAR "a", TVAR "b")];
+    domain = Type.[ARRAY (TVAR "T1", TVAR "T2"); ARRAY (TVAR "T1", TVAR "T2")];
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y)
                          | _ -> true);
-    evaluate = (fun [@warning "-8"]
-                Value.[ Array (a_key_type, a_val_type, a_elems, a_default_val)
+    evaluate = Value.(fun [@warning "-8"]
+                      [ Array (a_key_type, a_val_type, a_elems, a_default_val)
                       ; Array (b_key_type, b_val_type, b_elems, b_default_val) ]
-                -> Value.Bool (
-                     (Type.equal a_key_type b_key_type) &&
-                     (Type.equal a_val_type b_val_type) &&
-                     (Value.equal a_default_val b_default_val) &&
-                     (List.equal (Tuple.T2.equal ~eq1:Value.equal ~eq2:Value.equal)
-                                 (normalize a_elems)
-                                 (normalize b_elems))));
+                      -> Value.Bool (
+                           (Type.equal a_key_type b_key_type) &&
+                           (Type.equal a_val_type b_val_type) &&
+                           (Value.equal a_default_val b_default_val) &&
+                           (List.equal (Tuple.T2.equal ~eq1:Value.equal ~eq2:Value.equal)
+                                       (normalize a_elems)
+                                       (normalize b_elems))));
     to_string = (fun [@warning "-8"] [a ; b] -> "(= " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   }

--- a/src/BooleanComponents.ml
+++ b/src/BooleanComponents.ml
@@ -12,7 +12,7 @@ let all = [
                            -> false
                          | [ e ] -> not (is_constant e)
                          | _ -> false);
-    evaluate = (fun [@warning "-8"] Value.[Bool x] -> Value.Bool (not x));
+    evaluate = Value.(fun [@warning "-8"] [Bool x] -> Bool (not x));
     to_string = (fun [@warning "-8"] [a] -> "(not " ^ a ^ ")");
     global_constraints = (fun _ -> [])
   } ;
@@ -23,7 +23,7 @@ let all = [
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y) && (not (is_constant x || is_constant y))
                          | _ -> false);
-    evaluate = (fun [@warning "-8"] Value.[Bool x ; Bool y] -> Value.Bool (x && y));
+    evaluate = Value.(fun [@warning "-8"] [Bool x ; Bool y] -> Bool (x && y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(and " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   } ;
@@ -34,7 +34,7 @@ let all = [
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y) && (not (is_constant x || is_constant y))
                          | _ -> false);
-    evaluate = (fun [@warning "-8"] Value.[Bool x ; Bool y] -> Value.Bool (x || y));
+    evaluate = Value.(fun [@warning "-8"] [Bool x ; Bool y] -> Bool (x || y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(or " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   }

--- a/src/BooleanComponents.ml
+++ b/src/BooleanComponents.ml
@@ -12,29 +12,29 @@ let all = [
                            -> false
                          | [ e ] -> not (is_constant e)
                          | _ -> false);
-    evaluate = (fun [@warning "-8"] [Value.Bool x] -> Value.Bool (not x));
+    evaluate = (fun [@warning "-8"] Value.[Bool x] -> Value.Bool (not x));
     to_string = (fun [@warning "-8"] [a] -> "(not " ^ a ^ ")");
     global_constraints = (fun _ -> [])
   } ;
   {
     name = "and";
     codomain = Type.BOOL;
-    domain = [Type.BOOL; Type.BOOL];
+    domain = Type.[BOOL; BOOL];
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y) && (not (is_constant x || is_constant y))
                          | _ -> false);
-    evaluate = (fun [@warning "-8"] [Value.Bool x ; Value.Bool y] -> Value.Bool (x && y));
+    evaluate = (fun [@warning "-8"] Value.[Bool x ; Bool y] -> Value.Bool (x && y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(and " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   } ;
   {
     name = "or";
     codomain = Type.BOOL;
-    domain = [Type.BOOL; Type.BOOL];
+    domain = Type.[BOOL; BOOL];
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y) && (not (is_constant x || is_constant y))
                          | _ -> false);
-    evaluate = (fun [@warning "-8"] [Value.Bool x ; Value.Bool y] -> Value.Bool (x || y));
+    evaluate = (fun [@warning "-8"] Value.[Bool x ; Bool y] -> Value.Bool (x || y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(or " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   }

--- a/src/Exceptions.ml
+++ b/src/Exceptions.ml
@@ -1,13 +1,19 @@
+(* raised by the frontend (SyGuS parser) *)
 exception Parse_Exn of string
-exception Internal_Exn of string
-exception Illegal_Call_Exn of string
-exception Invalid_Type_Exn of string
-exception False_Pre_Exn of string
+
+(* raised if a bad test (counterexample) is generated *)
 exception Ambiguous_Test of string
 exception Duplicate_Test of string
-exception Unification_Exn of string
 
-(* thrown if there is no boolean function consistent with the given
+(* raised in case of logical errors that must be fixed *)
+exception Internal_Exn of string
+
+(* raised by the synthesizer *)
+exception Enumeration_Exn of string
+exception Unification_Exn of string
+exception Transformation_Exn of string
+
+(* raised if there is no boolean function consistent with the given
    positive and negative examples. Possible in two situations:
      > a positive and negative example have the identical feature vector
      > there is no k-CNF formula (for some particular k being used)
@@ -16,6 +22,6 @@ exception Unification_Exn of string
 exception NoSuchFunction
 exception ClauseEncodingError
 
-(* a postcondition should raise this exception to indicate
+(* raised by a postcondition to indicate
    that the given test input should be ignored *)
 exception IgnoreTest

--- a/src/IntegerComponents.ml
+++ b/src/IntegerComponents.ml
@@ -8,11 +8,11 @@ let equality = [
   {
     name = "int-eq";
     codomain = Type.BOOL;
-    domain = [Type.INT; Type.INT];
+    domain = Type.[INT; INT];
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y) && (not (is_constant x && is_constant y))
                          | _ -> false);
-    evaluate = (function [@warning "-8"] [Value.Int x ; Value.Int y] -> Value.Bool (x = y));
+    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Bool (x = y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(= " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   }
@@ -22,44 +22,44 @@ let intervals = equality @ [
    {
     name = "int-geq";
     codomain = Type.BOOL;
-    domain = [Type.INT; Type.INT];
+    domain = Type.[INT; INT];
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y) && (not (is_constant x && is_constant y))
                          | _ -> false);
-    evaluate = (function [@warning "-8"] [Value.Int x ; Value.Int y] -> Value.Bool (x >= y));
+    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Bool (x >= y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(>= " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   } ;
   {
     name = "int-leq";
     codomain = Type.BOOL;
-    domain = [Type.INT; Type.INT];
+    domain = Type.[INT; INT];
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y) && (not (is_constant x && is_constant y))
                          | _ -> false);
-    evaluate = (function [@warning "-8"] [Value.Int x ; Value.Int y] -> Value.Bool (x <= y));
+    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Bool (x <= y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(<= " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   } ;
   {
     name = "int-lt";
     codomain = Type.BOOL;
-    domain = [Type.INT; Type.INT];
+    domain = Type.[INT; INT];
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y) && (not (is_constant x && is_constant y))
                          | _ -> false);
-    evaluate = (function [@warning "-8"] [Value.Int x ; Value.Int y] -> Value.Bool (x < y));
+    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Bool (x < y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(< " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   } ;
   {
     name = "int-gt";
     codomain = Type.BOOL;
-    domain = [Type.INT; Type.INT];
+    domain = Type.[INT; INT];
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y) && (not (is_constant x && is_constant y))
                          | _ -> false);
-    evaluate = (function [@warning "-8"] [Value.Int x ; Value.Int y] -> Value.Bool (x > y));
+    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Bool (x > y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(> " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   }
@@ -69,7 +69,7 @@ let octagons = intervals @ [
   {
     name = "int-add";
     codomain = Type.INT;
-    domain = [Type.INT; Type.INT];
+    domain = Type.[INT; INT];
     is_argument_valid = (function
                          | [x ; FCall (comp, [_ ; y])]
                            when String.equal comp.name "int-sub"
@@ -79,14 +79,14 @@ let octagons = intervals @ [
                            -> x =/= y && (y =/= Const (Value.Int 0))
                          | [x ; y] -> (x =/= Const (Value.Int 0)) && (y =/= Const (Value.Int 0))
                          | _ -> false);
-    evaluate = (function [@warning "-8"] [Value.Int x ; Value.Int y] -> Value.Int (x + y));
+    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Int (x + y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(+ " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   } ;
   {
     name = "int-sub";
     codomain = Type.INT;
-    domain = [Type.INT; Type.INT];
+    domain = Type.[INT; INT];
     is_argument_valid = (function
                          | [(FCall (comp, [x ; y])) ; z]
                            when String.equal comp.name "int-add"
@@ -100,7 +100,7 @@ let octagons = intervals @ [
                          | [x ; y] -> (x =/= y)
                                    && (x =/= Const (Value.Int 0)) && (y =/= Const (Value.Int 0))
                          | _ -> false);
-    evaluate = (function [@warning "-8"] [Value.Int x ; Value.Int y] -> Value.Int (x - y));
+    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Int (x - y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(- " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   }
@@ -110,14 +110,14 @@ let polyhedra = octagons @ [
   {
     name = "int-lin-mult";
     codomain = Type.INT;
-    domain = [Type.INT; Type.INT];
+    domain = Type.[INT; INT];
     is_argument_valid = (function
                          | [x ; y]
                            -> (x =/= Const (Value.Int 0)) && (x =/= Const (Value.Int 1))
                            && (y =/= Const (Value.Int 0)) && (y =/= Const (Value.Int 1))
                            && (is_constant x || is_constant y)
                          | _ -> false);
-    evaluate = (function [@warning "-8"] [Value.Int x ; Value.Int y] -> Value.Int (x * y));
+    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Int (x * y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(* " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   }
@@ -127,11 +127,11 @@ let polynomials = polyhedra @ [
   {
     name = "int-nonlin-mult";
     codomain = Type.INT;
-    domain = [Type.INT; Type.INT];
+    domain = Type.[INT; INT];
     is_argument_valid = (function
                          | [x ; y] -> not (is_constant x || is_constant y)
                          | _ -> false);
-    evaluate = (function [@warning "-8"] [Value.Int x ; Value.Int y] -> Value.Int (x * y));
+    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Int (x * y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(* " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   }
@@ -141,28 +141,28 @@ let peano = polynomials @ [
   {
     name = "int-div";
     codomain = Type.INT;
-    domain = [Type.INT; Type.INT];
+    domain = Type.[INT; INT];
     is_argument_valid = (function
                          | [x ; y] -> x =/= y
                                    && (x =/= Const (Value.Int 0)) && (x =/= Const (Value.Int 1))
                                    && (y =/= Const (Value.Int 0)) && (y =/= Const (Value.Int 1))
                          | _ -> false);
     evaluate = (function [@warning "-8"]
-                | [Value.Int x ; Value.Int y] when y <> 0 -> Value.Int (pos_div x y));
+                | Value.[Int x ; Int y] when y <> 0 -> Value.Int (pos_div x y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(div " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun [@warning "-8"] [_ ; b] -> ["(not (= 0 " ^ b ^ "))"]);
   } ;
   {
     name = "int-mod";
     codomain = Type.INT;
-    domain = [Type.INT; Type.INT];
+    domain = Type.[INT; INT];
     is_argument_valid = (function
                          | [x ; y] -> x =/= y
                                    && (x =/= Const (Value.Int 0)) && (x =/= Const (Value.Int 1))
                                    && (y =/= Const (Value.Int 0)) && (y =/= Const (Value.Int 1))
                          | _ -> false);
     evaluate = (function [@warning "-8"]
-                | [Value.Int x ; Value.Int y] when y <> 0 -> Value.Int (x % y));
+                | Value.[Int x ; Int y] when y <> 0 -> Value.Int (x % y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(mod " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun [@warning "-8"] [_ ; b] -> ["(not (= 0 " ^ b ^ "))"]);
   }

--- a/src/IntegerComponents.ml
+++ b/src/IntegerComponents.ml
@@ -12,7 +12,7 @@ let equality = [
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y) && (not (is_constant x && is_constant y))
                          | _ -> false);
-    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Bool (x = y));
+    evaluate = Value.(fun [@warning "-8"] [Int x ; Int y] -> Bool Int.(x = y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(= " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   }
@@ -26,7 +26,7 @@ let intervals = equality @ [
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y) && (not (is_constant x && is_constant y))
                          | _ -> false);
-    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Bool (x >= y));
+    evaluate = Value.(fun [@warning "-8"] [Int x ; Int y] -> Bool Int.(x >= y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(>= " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   } ;
@@ -37,7 +37,7 @@ let intervals = equality @ [
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y) && (not (is_constant x && is_constant y))
                          | _ -> false);
-    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Bool (x <= y));
+    evaluate = Value.(fun [@warning "-8"] [Int x ; Int y] -> Bool Int.(x <= y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(<= " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   } ;
@@ -48,7 +48,7 @@ let intervals = equality @ [
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y) && (not (is_constant x && is_constant y))
                          | _ -> false);
-    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Bool (x < y));
+    evaluate = Value.(fun [@warning "-8"] [Int x ; Int y] -> Bool Int.(x < y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(< " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   } ;
@@ -59,7 +59,7 @@ let intervals = equality @ [
     is_argument_valid = (function
                          | [x ; y] -> (x =/= y) && (not (is_constant x && is_constant y))
                          | _ -> false);
-    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Bool (x > y));
+    evaluate = Value.(fun [@warning "-8"] [Int x ; Int y] -> Bool Int.(x > y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(> " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   }
@@ -70,16 +70,16 @@ let octagons = intervals @ [
     name = "int-add";
     codomain = Type.INT;
     domain = Type.[INT; INT];
-    is_argument_valid = (function
-                         | [x ; FCall (comp, [_ ; y])]
-                           when String.equal comp.name "int-sub"
-                           -> x =/= y && (x =/= Const (Value.Int 0))
-                         | [FCall (comp, [_ ; x]) ; y]
-                           when String.equal comp.name "int-sub"
-                           -> x =/= y && (y =/= Const (Value.Int 0))
-                         | [x ; y] -> (x =/= Const (Value.Int 0)) && (y =/= Const (Value.Int 0))
-                         | _ -> false);
-    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Int (x + y));
+    is_argument_valid = Value.(function
+                               | [x ; FCall (comp, [_ ; y])]
+                                 when String.equal comp.name "int-sub"
+                                 -> x =/= y && (x =/= Const (Int 0))
+                               | [FCall (comp, [_ ; x]) ; y]
+                                 when String.equal comp.name "int-sub"
+                                 -> x =/= y && (y =/= Const (Int 0))
+                               | [x ; y] -> (x =/= Const (Int 0)) && (y =/= Const (Int 0))
+                               | _ -> false);
+    evaluate = Value.(fun [@warning "-8"] [Int x ; Int y] -> Int (x + y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(+ " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   } ;
@@ -87,20 +87,20 @@ let octagons = intervals @ [
     name = "int-sub";
     codomain = Type.INT;
     domain = Type.[INT; INT];
-    is_argument_valid = (function
-                         | [(FCall (comp, [x ; y])) ; z]
-                           when String.equal comp.name "int-add"
-                           -> x =/= z && y =/= z && (z =/= Const (Value.Int 0))
-                         | [(FCall (comp, [x ; _])) ; y]
-                           when String.equal comp.name "int-sub"
-                           -> x =/= y && (y =/= Const (Value.Int 0))
-                         | [x ; (FCall (comp, [y ; _]))]
-                           when (String.equal comp.name "int-sub" || String.equal comp.name "int-add")
-                           -> x =/= y
-                         | [x ; y] -> (x =/= y)
-                                   && (x =/= Const (Value.Int 0)) && (y =/= Const (Value.Int 0))
-                         | _ -> false);
-    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Int (x - y));
+    is_argument_valid = Value.(function
+                               | [(FCall (comp, [x ; y])) ; z]
+                                 when String.equal comp.name "int-add"
+                                 -> x =/= z && y =/= z && (z =/= Const (Int 0))
+                               | [(FCall (comp, [x ; _])) ; y]
+                                 when String.equal comp.name "int-sub"
+                                 -> x =/= y && (y =/= Const (Int 0))
+                               | [x ; (FCall (comp, [y ; _]))]
+                                 when (String.equal comp.name "int-sub" || String.equal comp.name "int-add")
+                                 -> x =/= y
+                               | [x ; y] -> (x =/= y)
+                                         && (x =/= Const (Int 0)) && (y =/= Const (Int 0))
+                               | _ -> false);
+    evaluate = Value.(fun [@warning "-8"] [Int x ; Int y] -> Int (x - y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(- " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   }
@@ -111,13 +111,13 @@ let polyhedra = octagons @ [
     name = "int-lin-mult";
     codomain = Type.INT;
     domain = Type.[INT; INT];
-    is_argument_valid = (function
-                         | [x ; y]
-                           -> (x =/= Const (Value.Int 0)) && (x =/= Const (Value.Int 1))
-                           && (y =/= Const (Value.Int 0)) && (y =/= Const (Value.Int 1))
-                           && (is_constant x || is_constant y)
-                         | _ -> false);
-    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Int (x * y));
+    is_argument_valid = Value.(function
+                               | [x ; y]
+                                 -> (x =/= Const (Int 0)) && (x =/= Const (Int 1))
+                                 && (y =/= Const (Int 0)) && (y =/= Const (Int 1))
+                                 && (is_constant x || is_constant y)
+                               | _ -> false);
+    evaluate = Value.(fun [@warning "-8"] [Int x ; Int y] -> Int (x * y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(* " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   }
@@ -128,10 +128,10 @@ let polynomials = polyhedra @ [
     name = "int-nonlin-mult";
     codomain = Type.INT;
     domain = Type.[INT; INT];
-    is_argument_valid = (function
-                         | [x ; y] -> not (is_constant x || is_constant y)
-                         | _ -> false);
-    evaluate = (function [@warning "-8"] Value.[Int x ; Int y] -> Value.Int (x * y));
+    is_argument_valid = Value.(function
+                               | [x ; y] -> not (is_constant x || is_constant y)
+                               | _ -> false);
+    evaluate = Value.(fun [@warning "-8"] [Int x ; Int y] -> Int (x * y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(* " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun _ -> [])
   }
@@ -142,13 +142,14 @@ let peano = polynomials @ [
     name = "int-div";
     codomain = Type.INT;
     domain = Type.[INT; INT];
-    is_argument_valid = (function
-                         | [x ; y] -> x =/= y
-                                   && (x =/= Const (Value.Int 0)) && (x =/= Const (Value.Int 1))
-                                   && (y =/= Const (Value.Int 0)) && (y =/= Const (Value.Int 1))
-                         | _ -> false);
-    evaluate = (function [@warning "-8"]
-                | Value.[Int x ; Int y] when y <> 0 -> Value.Int (pos_div x y));
+    is_argument_valid = Value.(function
+                               | [x ; y] -> x =/= y
+                                         && (x =/= Const (Int 0)) && (x =/= Const (Int 1))
+                                         && (y =/= Const (Int 0)) && (y =/= Const (Int 1))
+                               | _ -> false);
+    evaluate = Value.(function [@warning "-8"]
+                      [Int x ; Int y] when Int.(y <> 0)
+                      -> Int (pos_div x y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(div " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun [@warning "-8"] [_ ; b] -> ["(not (= 0 " ^ b ^ "))"]);
   } ;
@@ -156,13 +157,14 @@ let peano = polynomials @ [
     name = "int-mod";
     codomain = Type.INT;
     domain = Type.[INT; INT];
-    is_argument_valid = (function
-                         | [x ; y] -> x =/= y
-                                   && (x =/= Const (Value.Int 0)) && (x =/= Const (Value.Int 1))
-                                   && (y =/= Const (Value.Int 0)) && (y =/= Const (Value.Int 1))
-                         | _ -> false);
-    evaluate = (function [@warning "-8"]
-                | Value.[Int x ; Int y] when y <> 0 -> Value.Int (x % y));
+    is_argument_valid = Value.(function
+                               | [x ; y] -> x =/= y
+                                         && (x =/= Const (Int 0)) && (x =/= Const (Int 1))
+                                         && (y =/= Const (Int 0)) && (y =/= Const (Int 1))
+                               | _ -> false);
+    evaluate = Value.(function [@warning "-8"]
+                      [Int x ; Int y] when Int.(y <> 0)
+                      -> Int (x % y));
     to_string = (fun [@warning "-8"] [a ; b] -> "(mod " ^ a ^ " " ^ b ^ ")");
     global_constraints = (fun [@warning "-8"] [_ ; b] -> ["(not (= 0 " ^ b ^ "))"]);
   }

--- a/src/ListComponents.ml
+++ b/src/ListComponents.ml
@@ -1,0 +1,121 @@
+open Base
+
+open Expr
+
+let all_qf = [
+  {
+    name = "length";
+    codomain = Type.INT;
+    domain = Type.[LIST (TVAR "a")];
+    is_argument_valid = (function _ -> true);
+    evaluate = Value.(fun [@warning "-8"] [List (_,l)] -> Int (List.length l));
+    to_string = (fun [@warning "-8"] [a] -> "(len " ^ a ^ ")");
+    global_constraints = (fun _ -> [])
+  } ;
+  {
+    name = "hd";
+    codomain = Type.TVAR "a";
+    domain = Type.[LIST (TVAR "a")];
+    is_argument_valid = (function _ -> true);
+    evaluate = Value.(fun [@warning "-8"] [List (_,l)] -> List.hd_exn l);
+    to_string = (fun [@warning "-8"] [a] -> "(hd " ^ a ^ ")");
+    global_constraints = (fun _ -> [])
+  } ;
+  {
+    name = "tl";
+    codomain = Type.(LIST (TVAR "a"));
+    domain = Type.[LIST (TVAR "a")];
+    is_argument_valid = (function _ -> true);
+    evaluate = Value.(fun [@warning "-8"] [List (t,l)] -> List (t, (List.tl_exn l)));
+    to_string = (fun [@warning "-8"] [a] -> "(tl " ^ a ^ ")");
+    global_constraints = (fun _ -> [])
+  }
+]
+
+let all = all_qf @ [
+  {
+    name = "all";
+    codomain = Type.BOOL;
+    domain = Type.[LIST BOOL];
+    is_argument_valid = (function _ -> true);
+    evaluate = Value.(fun [@warning "-8"] [List (_,l)]
+                      -> Bool (List.for_all l ~f:(fun [@warning "-8"] (Bool b) -> b)));
+    to_string = (fun [@warning "-8"] [a] -> "(all " ^ a ^ ")");
+    global_constraints = (fun _ -> [])
+  } ;
+  {
+    name = "any";
+    codomain = Type.BOOL;
+    domain = Type.[LIST BOOL];
+    is_argument_valid = (function _ -> true);
+    evaluate = Value.(fun [@warning "-8"] [List (_,l)]
+                      -> Bool (List.exists l ~f:(fun [@warning "-8"] (Bool b) -> b)));
+    to_string = (fun [@warning "-8"] [a] -> "(any " ^ a ^ ")");
+    global_constraints = (fun _ -> [])
+  }
+]
+
+let map_transform_unary (component : component) : component =
+  match component.domain with
+  | [dom] -> let name = "map-" ^ component.name
+              in { name;
+                   codomain = Type.LIST component.codomain;
+                   domain = Type.[LIST dom];
+                   is_argument_valid = (function _ -> true);
+                   evaluate = Value.(fun [@warning "-8"] [ List (_,l) ]
+                                     -> List ((Type.LIST component.codomain),
+                                              (List.map l ~f:(fun e -> component.evaluate [e]))));
+                   to_string = (fun [@warning "-8"] [a] -> "(" ^ name ^ " " ^ a ^ ")" );
+                   global_constraints = (fun _ -> [])
+                  }
+  | l -> raise (Exceptions.Transformation_Exn (
+                  "Cannot transform a " ^ (Int.to_string (List.length l)) ^ "-ary component " ^ component.name))
+
+let all_transformed_int_unary =
+  all @ (List.filter_map IntegerComponents.polynomials
+                         ~f:(fun c -> try Some (map_transform_unary c)
+                                      with _ -> None))
+
+(* FIXME: We create two map versions of each binary component:
+          One that fixes the first argument and another that fixes the second.
+          However, these would be equivalent for commutative components;
+          so may be keep a `commutative` attribute for each component,
+          or, implement a better, more general strategy for component transformation. *)
+
+let map_transform_binary (component : component) : component list =
+  match component.domain with
+  | [d1 ; d2]
+    -> let nameL = "map-fixL-" ^ component.name in
+       let nameR = "map-fixR-" ^ component.name
+        in [{
+              name = nameL;
+              codomain = Type.LIST component.codomain;
+              domain = Type.[LIST d1 ; d2];
+              is_argument_valid = (function _ -> true);
+              evaluate = Value.(fun [@warning "-8"] [List (_, x) ; y]
+                                -> List (Type.LIST component.codomain,
+                                         (List.map x ~f:(fun e -> component.evaluate [e ; y]))));
+              to_string = (fun [@warning "-8"] [a ; b] -> "(" ^ nameL ^ " " ^ a ^ " " ^ b ^ ")");
+              global_constraints = (fun _ -> [])
+            } ;
+            {
+              name = nameR;
+              codomain = Type.LIST component.codomain;
+              domain = Type.[d1 ; LIST d2];
+              is_argument_valid = (function _ -> true);
+              evaluate = Value.(fun [@warning "-8"] [x ; List (_, y)]
+                                -> List (Type.LIST component.codomain,
+                                         (List.map y ~f:(fun e -> component.evaluate [x ; e]))));
+              to_string = (fun [@warning "-8"] [a ; b] -> "(" ^ nameR ^ " " ^ a ^ " " ^ b ^ ")");
+              global_constraints = (fun _ -> [])
+            }]
+  | l -> raise (Exceptions.Transformation_Exn (
+                  "Cannot transform a " ^ (Int.to_string (List.length l)) ^ "-ary component " ^ component.name))
+
+let all_transformed_int_binary =
+  all_transformed_int_unary @
+  List.(concat (filter_map IntegerComponents.polynomials
+                           ~f:(fun c -> try Some (map_transform_binary c)
+                                        with _ -> None)))
+
+let levels = [| all_qf ; all ; all_transformed_int_unary ; all_transformed_int_binary |]

--- a/src/Logic.ml
+++ b/src/Logic.ml
@@ -8,13 +8,12 @@ type t = {
 
 (* TODO: Think about better strategies for combining grammar levels across multiple theories.
          Given levels L1 = {Ga_1 ⊆ ... Ga_m} and L2 = {Gb_1 ⊆ ... Gb_n}, such that n > m,
-         currently I pad L1 with empty grammars in the beginning such that |L1| = |L2|
-         and then take a pairwise union. *)
+         currently I pad L1 with Ga_m at the end such that |L1| = |L2| and take a pairwise union. *)
 
 let rec ( ++ ) = fun x y ->
   if Array.(length y > length x) then y ++ x
   else Array.(map ~f:(fun (ex,ey) -> ex @ ey)
-                  (zip_exn x (append (create [] ~len:(length x - length y)) y)))
+                  (zip_exn x (append y (create (last y) ~len:(length x - length y)))))
 
 let all_supported =
    let table = String.Table.create () ~size:8

--- a/src/Logic.ml
+++ b/src/Logic.ml
@@ -6,31 +6,45 @@ type t = {
   sample_set_size_multiplier : int
 }
 
-let ( *** ) = fun x y ->
-  Array.(map ~f:(fun (ex,ey) -> ex @ ey) (cartesian_product x y))
+(* TODO: Think about better strategies for combining grammar levels across multiple theories.
+         Given levels L1 = {Ga_1 ⊆ ... Ga_m} and L2 = {Gb_1 ⊆ ... Gb_n}, such that n > m,
+         currently I pad L1 with empty grammars in the beginning such that |L1| = |L2|
+         and then take a pairwise union. *)
+
+let rec ( ++ ) = fun x y ->
+  if Array.(length y > length x) then y ++ x
+  else Array.(map ~f:(fun (ex,ey) -> ex @ ey)
+                  (zip_exn x (append (create [] ~len:(length x - length y)) y)))
 
 let all_supported =
-   let table = String.Table.create () ~size:2
+   let table = String.Table.create () ~size:8
    in List.iter ~f:(fun component -> String.Table.set table ~key:component.name ~data:component)
-        [{
-           name = "LIA" ;
-           components_per_level = BooleanComponents.levels *** IntegerComponents.linear_levels ;
-           sample_set_size_multiplier = 1
-         } ; {
-           name = "NIA" ;
-           components_per_level = BooleanComponents.levels *** IntegerComponents.non_linear_levels ;
-           sample_set_size_multiplier = 8
-         } ; {
-           name = "ALIA" ;
-           (* FIXME: Determine levels of ArrayComponents for hybrid enumeration *)
-           components_per_level = ArrayComponents.levels *** BooleanComponents.levels *** IntegerComponents.linear_levels ;
-           sample_set_size_multiplier = 1
-         } ; {
-           name = "ANIA" ;
-           (* FIXME: Determine levels of ArrayComponents for hybrid enumeration *)
-           components_per_level = ArrayComponents.levels *** BooleanComponents.levels *** IntegerComponents.non_linear_levels ;
-           sample_set_size_multiplier = 8
-        }]
+                [{
+                   name = "LIA" ;
+                   components_per_level = BooleanComponents.levels ++ IntegerComponents.linear_levels ;
+                   sample_set_size_multiplier = 1
+                 } ; {
+                   name = "NIA" ;
+                   components_per_level = BooleanComponents.levels ++ IntegerComponents.non_linear_levels ;
+                   sample_set_size_multiplier = 8
+                 } ; {
+                   name = "ALIA" ;
+                   (* FIXME: Determine levels of ArrayComponents for hybrid enumeration *)
+                   components_per_level = ArrayComponents.levels ++ BooleanComponents.levels ++ IntegerComponents.linear_levels ;
+                   sample_set_size_multiplier = 1
+                 } ; {
+                   name = "ANIA" ;
+                   (* FIXME: Determine levels of ArrayComponents for hybrid enumeration *)
+                   components_per_level = ArrayComponents.levels ++ BooleanComponents.levels ++ IntegerComponents.non_linear_levels ;
+                   sample_set_size_multiplier = 8
+                 } ; {
+                   name = "ALL" ;
+                   (* FIXME: The verification side for lists, especially with transformed components,
+                             doesn't work as of now -- we need to emit valid SMTLIB expressions for them *)
+                   components_per_level = ArrayComponents.levels ++ BooleanComponents.levels
+                                       ++ IntegerComponents.non_linear_levels ++ ListComponents.levels ;
+                   sample_set_size_multiplier = 8
+                }]
     ; table
 
 let of_string name = String.Table.find_exn all_supported name

--- a/src/Synthesizer.ml
+++ b/src/Synthesizer.ml
@@ -9,17 +9,17 @@ module Config = struct
   type t = {
     cost_limit : int ;
     cost_attribute : cost_attr ;
-    cost_function : int -> int -> float ;
     logic : Logic.t ;
     max_expressiveness_level : int ;
+    order : int -> int -> float ;
   }
 
   let default : t = {
-    cost_limit = 25 ;
+    cost_limit = 32 ;
     cost_attribute = Size ;
-    cost_function = (fun g_cost e_cost -> (Int.to_float e_cost) *. (Float.log (Int.to_float g_cost))) ;
     logic = Logic.of_string "LIA" ;
-    max_expressiveness_level = 4 ;
+    max_expressiveness_level = 1024 ;
+    order = (fun g_cost e_cost -> (Int.to_float e_cost) *. (Float.log (Int.to_float g_cost))) ;
   }
 end
 
@@ -149,30 +149,32 @@ let subtract ~(from : Expr.component list) (comps : Expr.component list) =
 
 let solve_impl (config : Config.t) (task : task) (stats : stats) =
   let typed_components t_type =
-    let equal_f cod = match cod , t_type with
-      | Type.ARRAY _ , Type.ARRAY _ -> true
-      | Type.TVAR _, _ -> true
-      | cod, t_type -> Poly.equal cod t_type
-    in
-    Array.append
-    (Array.create ~len:1 [])
-    (Array.mapi (Array.init (Int.min config.max_expressiveness_level (Array.length config.logic.components_per_level))
-                            ~f:(fun i -> config.logic.components_per_level.(i)))
+    let equal_f cod = Type.(match cod , t_type with
+                            | ARRAY _ , ARRAY _ -> true
+                            | LIST _ , LIST _ -> true
+                            | TVAR _, _ -> true
+                            | cod, t_type -> equal cod t_type)
+     in Array.(append
+          (create ~len:1 [])
+          (mapi (init (Base.Int.min config.max_expressiveness_level (length config.logic.components_per_level))
+                      ~f:(fun i -> config.logic.components_per_level.(i)))
                 ~f:(fun level comps
                     -> List.filter ~f:(fun c -> equal_f c.codomain)
                                    (if level < 1 then comps
-                                    else subtract ~from:comps (config.logic.components_per_level.(level - 1))))) in
+                                    else subtract ~from:comps (config.logic.components_per_level.(level - 1))))))
+   in
 
   let int_components = typed_components Type.INT in
   let bool_components = typed_components Type.BOOL in
   let char_components = typed_components Type.CHAR in
   let string_components = typed_components Type.STRING in
-  let list_components = typed_components Type.LIST in
-  let poly_array_components = typed_components (Type.ARRAY ((TVAR "_"), (TVAR "_"))) in
+  let poly_list_components = typed_components Type.(LIST (TVAR "_")) in
+  let poly_array_components = typed_components Type.(ARRAY (TVAR "_", TVAR "_")) in
 
   let empty_candidates () =
-    Array.init ((Array.length config.logic.components_per_level) + 1)
-      ~f:(fun _ -> Array.init config.cost_limit ~f:(fun _ -> DList.create ())) in
+    Array.(init ((length config.logic.components_per_level) + 1)
+                ~f:(fun _ -> init config.cost_limit ~f:(fun _ -> DList.create ())))
+   in
 
   let int_candidates = empty_candidates () in
   let bool_candidates = empty_candidates () in
@@ -182,15 +184,17 @@ let solve_impl (config : Config.t) (task : task) (stats : stats) =
   let array_candidates = empty_candidates () in
 
   let typed_candidates ?(no_tvar = false) = function
-    | Type.INT -> int_candidates
-    | Type.BOOL -> bool_candidates
-    | Type.CHAR -> char_candidates
-    | Type.STRING -> string_candidates
-    | Type.LIST -> list_candidates
+    | Type.INT     -> int_candidates
+    | Type.BOOL    -> bool_candidates
+    | Type.CHAR    -> char_candidates
+    | Type.STRING  -> string_candidates
+    | Type.LIST _  -> list_candidates
     | Type.ARRAY _ -> array_candidates
-    | Type.TVAR _ when no_tvar = false -> raise (Internal_Exn "No candidates for TVAR")
+    | Type.TVAR _ when no_tvar = false
+      -> raise (Internal_Exn "No candidates for TVAR")
     | Type.TVAR _ -> let (@) = Array.append
-                      in int_candidates @ bool_candidates @ char_candidates @ string_candidates @ list_candidates @ array_candidates
+                      in int_candidates @ bool_candidates @ char_candidates
+                       @ string_candidates @ list_candidates @ array_candidates
   in
 
   let seen_outputs = ref (Set.empty (module Output)) in
@@ -255,8 +259,9 @@ let solve_impl (config : Config.t) (task : task) (stats : stats) =
                                   ^ ")"))
         | Some unified_component -> begin
             let cod = match unified_component.codomain with
-                    | Type.ARRAY (_,_) -> Type.ARRAY (Type.TVAR "_" , Type.TVAR "_")
-                    | cod -> cod
+                      | Type.ARRAY (_,_) -> Type.ARRAY (Type.TVAR "_" , Type.TVAR "_")
+                      | Type.LIST _ -> Type.LIST (Type.TVAR "_")
+                      | cod -> cod
              in if not (Type.equal cod cand_type) then
                   Log.debug (lazy ("The candidate type " ^ (Type.to_string cand_type) ^ " did not match the codomain " ^ (Type.to_string cod)))
                 else begin
@@ -276,8 +281,8 @@ let solve_impl (config : Config.t) (task : task) (stats : stats) =
   let ordered_level_cost =
     let grammar_cost level = (List.length constants) * (List.length config.logic.components_per_level.(level-1))
     in List.sort ~compare:(fun (level1,cost1) (level2,cost2)
-                           -> Float.compare (config.cost_function (grammar_cost level1) cost1)
-                                            (config.cost_function (grammar_cost level2) cost2))
+                           -> Float.compare (config.order (grammar_cost level1) cost1)
+                                            (config.order (grammar_cost level2) cost2))
                  (List.cartesian_product (List.range 1 ~stop:`inclusive (Int.min config.max_expressiveness_level (Array.length config.logic.components_per_level)))
                                          (List.range 2 config.cost_limit))
   in
@@ -292,11 +297,10 @@ let solve_impl (config : Config.t) (task : task) (stats : stats) =
     ~f:(fun (level,cost)
         -> List.(iter (cartesian_product (range ~stop:`inclusive 1 level) (range 2 cost))
              ~f:(fun (l,c) -> if not (Set.mem !seen_level_cost (l,c))
-                              then failwith ( "Internal Error :: Bad guiding function for synthesis. "
-                                            ^ "Exploring (G=" ^ (Int.to_string level)
+                              then failwith ( "Internal Error :: Not a well order! "
+                                            ^ "Attempted to explore (G=" ^ (Int.to_string level)
                                             ^ ",k=" ^ (Int.to_string cost) ^ ") before (G="
-                                            ^ (Int.to_string l) ^ ",k=" ^ (Int.to_string c)
-                                            ^ ")!")))
+                                            ^ (Int.to_string l) ^ ",k=" ^ (Int.to_string c) ^ ")")))
          ; seen_level_cost := (Set.add !seen_level_cost (level, cost))
          ; List.iter (List.range 1 ~stop:`inclusive level)
              ~f:(fun l -> List.iter2_exn
@@ -304,19 +308,25 @@ let solve_impl (config : Config.t) (task : task) (stats : stats) =
                                  ; (INT, int_candidates)
                                  ; (CHAR, char_candidates)
                                  ; (STRING, string_candidates)
-                                 ; (LIST, list_candidates)
+                                 ; (LIST (TVAR "_"), list_candidates)
                                  ; (ARRAY (TVAR "_", TVAR "_"), array_candidates) ]
                             [ bool_components.(l)
                             ; int_components.(l)
                             ; char_components.(l)
                             ; string_components.(l)
-                            ; list_components.(l)
+                            ; poly_list_components.(l)
                             ; poly_array_components.(l) ]
                             ~f:(fun (cand_type, cands) comps
                                 -> List.iter comps ~f:(expand_component l level cost cands cand_type))))
 
 let solve ?(config = Config.default) (task : task) : result =
-  Log.debug (lazy ("Running enumerative synthesis:"));
+  Log.debug (lazy ("Running enumerative synthesis" ^ (config.logic.name) ^ ":"));
+  Log.debug (lazy ( "  > Sizes of provided grammars:"
+                  ^ (Array.to_string_map config.logic.components_per_level
+                                         ~sep:", " ~f:(fun l -> Int.to_string (List.length l)))));
+  if not (Array.is_sorted ~compare:Int.compare
+                          (Array.map config.logic.components_per_level ~f:List.length))
+  then raise (Enumeration_Exn ("Provided grammars are not monotonically increasing in expressiveness"));
   let start_time = Time.now () in
   let stats = { enumerated = 0 ; pruned = 0 ; synth_time_ms = 0.0 } in
   try solve_impl config task stats

--- a/src/TestGen.ml
+++ b/src/TestGen.ml
@@ -12,8 +12,8 @@ let rec for_type (t : Type.t) : Value.t Generator.t =
   | Type.STRING -> (Int.gen_incl 0 64)
                    >>= fun len -> (String.gen_with_length len (Char.gen_print)
                                   >>= fun s -> singleton (Value.String s))
-  | Type.LIST -> raise (Exceptions.Internal_Exn "Generators for List type not implemented!")
   | Type.ARRAY (key,value) -> (Int.gen_incl 0 64)
                               >>= fun len -> ((tuple2 (List.gen_with_length len (tuple2 (for_type key) (for_type value))) (for_type value))
                                               >>= fun (arr, def) -> singleton (Value.Array (key, value, arr, def)))
-  | Type.TVAR _ -> raise (Exceptions.Internal_Exn "Generators for TVAR type not implemented!")
+  | Type.LIST _ | Type.TVAR _
+    -> raise (Exceptions.Internal_Exn "Generator not implemented!")

--- a/src/Utils.ml
+++ b/src/Utils.ml
@@ -14,15 +14,15 @@ module List = struct
     String.concat ~sep (List.map l ~f)
 
   let to_string_mapi ~(sep : string) (l : 'a list) ~(f : int -> 'a -> string) : string =
-    String.concat ~sep (List.mapi l ~f)
+    String.concat ~sep (mapi ~f l)
 
   let to_string_map2 ~(sep : string) (l1 : 'a list) (l2 : 'b list)
                      ~(f : 'a -> 'b -> string) : string =
-    String.concat ~sep (List.map2_exn l1 l2 ~f)
+    String.concat ~sep (map2_exn ~f l1 l2)
 
   let range_map ?(stride = 1) ?(start = `inclusive) ?(stop = `exclusive)
                 ~(f : int -> 'a) (start_i : int) (stop_i : int) : 'a list =
-    List.(map (range ~stride ~start ~stop start_i stop_i) ~f)
+    map ~f (range ~stride ~start ~stop start_i stop_i)
 
   let dedup_and_stable_sort ?(which_to_keep=`Last) ~compare list =
     match list with
@@ -36,11 +36,11 @@ module Array = struct
   include Array
 
   let to_string_map ~(sep : string) (l : 'a array) ~(f : 'a -> string) : string =
-    String.concat_array ~sep (Array.map l ~f)
+    String.concat_array ~sep (map l ~f)
 
   let to_string_map2 ~(sep : string) (l1 : 'a array) (l2 : 'b array)
                      ~(f : 'a -> 'b -> string) : string =
-    String.concat_array ~sep (Array.map2_exn l1 l2 ~f)
+    String.concat_array ~sep (map2_exn l1 l2 ~f)
 end
 
 let get_in_channel = function

--- a/test/Test_Expr.ml
+++ b/test/Test_Expr.ml
@@ -14,7 +14,7 @@ let mock_store_component = {
   global_constraints = (fun _ -> []);
 }
 
-let unify_component_test () =
+let unify_success () =
   let arg_types = [ Type.ARRAY (Type.STRING,Type.INT) ; Type.STRING ] in
   let res = match unify_component mock_store_component arg_types with
     | None -> false
@@ -23,6 +23,12 @@ let unify_component_test () =
       && (List.equal Type.equal unified_comp.domain [Type.ARRAY (Type.STRING, Type.INT) ; Type.STRING])
    in Alcotest.(check bool) "identical" true res
 
+let unify_failure () =
+  let arg_types = [ Type.ARRAY (Type.STRING,Type.INT) ; Type.INT ] in
+  let res = unify_component mock_store_component arg_types
+   in Alcotest.(check bool) "identical" true (Option.is_none res)
+
 let all = [
-  "Component unification", `Quick, unify_component_test ;
+  "Successful unification",   `Quick, unify_success ;
+  "Unsuccessful unification", `Quick, unify_failure ;
 ]

--- a/test/Test_Synthesizer.ml
+++ b/test/Test_Synthesizer.ml
@@ -4,7 +4,7 @@ open LoopInvGen
 
 open Synthesizer
 
-let y_PLUS_x () =
+let plus_x_y () =
   let result = solve {
     arg_names = [ "x" ; "y" ];
     inputs = List.map ~f:(Array.map ~f:(fun i -> Value.Int i))
@@ -14,7 +14,7 @@ let y_PLUS_x () =
     constants = []
   } in Alcotest.(check string) "identical" "(+ x y)" result.string
 
-let y_MINUS_z_LE_x () =
+let ge_plus_x_z_y () =
   let result = solve {
     arg_names = [ "x" ; "y" ; "z" ];
     inputs = List.map ~f:(Array.map ~f:(fun i -> Value.Int i))
@@ -26,14 +26,14 @@ let y_MINUS_z_LE_x () =
     constants = []
   } in Alcotest.(check string) "identical" "(>= (+ x z) y)" result.string
 
-let y_MINUS_x_MINUS_z_LE_x () =
+let not_or_eq_w_x_eq_y_z () =
   let result = solve {
     arg_names = [ "w" ; "x" ; "y" ; "z" ];
     inputs = List.map ~f:(Array.map ~f:(fun i -> Value.Int i))
                [ [| 4 ; (-1) ; (-5) ; 1 ; (-1) ; 2 |]
                ; [| 3 ; 7 ; (-1) ; (-4) ; 1 ; 2 |]
                ; [| 9 ; (-3) ; (-10) ; 11 ; (-10) ; 2  |]
-               ; [| 4 ; (-6) ; (-10) ; 11 ; (-1) ; (-3) |] ];
+               ; [| 1 ; (-6) ; (-10) ; 11 ; (-1) ; (-3) |] ];
     outputs = Array.map ~f:(fun b -> Value.Bool b)
                         [| true ; true ; false ; false ; true ; false |];
     constants = []
@@ -42,41 +42,41 @@ let y_MINUS_x_MINUS_z_LE_x () =
 let select_a_k () =
   let result = solve ~config:{ Config.default with logic = Logic.of_string "ALIA" } {
     arg_names = [ "a" ; "k" ];
-    inputs = [ (Array.map ~f:(fun (a,b,c,d) -> Value.Array (a,b,c,d))
-                     [| (Type.INT, Type.STRING,
-                         [ (Value.Int 3, Value.String "30")
-                         ; (Value.Int 2, Value.String "20")
-                         ; (Value.Int 1, Value.String "10") ],
-                         Value.String "1")
-                      ; (Type.INT, Type.STRING,
-                         [ (Value.Int 2, Value.String "20") ; (Value.Int 1, Value.String "1024") ],
-                         Value.String "0")
-                      ; (Type.INT, Type.STRING,
-                         [ (Value.Int 0, Value.String "0") ],
-                         Value.String "30") |])
-             ; [| Value.Int 1 ; Value.Int 2 ; Value.Int 3 |] ];
-    outputs = [| Value.String "10" ; Value.String "20" ; Value.String "30" |];
+    inputs = Value.[
+      (Array.map ~f:(fun (a,b,c,d) -> Value.Array (a,b,c,d))
+                 [| (Type.INT, Type.STRING,
+                     [ (Int 3, String "30")
+                     ; (Int 2, String "20")
+                     ; (Int 1, String "10") ],
+                     String "1")
+                  ; (Type.INT, Type.STRING,
+                     [ (Int 2, String "20")
+                     ; (Int 1, String "1024") ],
+                     String "0")
+                  ; (Type.INT, Type.STRING,
+                     [ (Int 0, String "0") ],
+                     String "30") |]);
+      [| Int 1 ; Int 2 ; Int 3 |] ];
+    outputs = Value.[| String "10" ; String "20" ; String "30" |];
     constants = []
   } in Alcotest.(check string) "identical" "(select a k)" result.string
 
 let select_a_k__with_duplicates () =
   let result = solve ~config:{ Config.default with logic = Logic.of_string "ALIA" } {
     arg_names = [ "a" ; "k" ];
-    inputs = [ (Array.map ~f:(fun (a,b,c,d) -> Value.Array (a,b,c,d))
-                          [| (Type.INT, Type.INT,
-                              [ (Value.Int 3, Value.Int 10)
-                              ; (Value.Int 3, Value.Int 30)
-                              ; (Value.Int 2, Value.Int 20)
-                              ; (Value.Int 1, Value.Int 10) ],
-                              Value.Int 1)
-                           ; (Type.INT, Type.INT,
-                              [ (Value.Int 2, Value.Int 20) ; (Value.Int 1, Value.Int 1024) ],
-                              Value.Int 0)
-                           ; (Type.INT, Type.INT,
-                              [ (Value.Int 0 , Value.Int 0)],
-                              Value.Int 30) |])
-             ; [| Value.Int 3 ; Value.Int 2 ; Value.Int 3 |] ];
-    outputs = [| Value.Int 10 ; Value.Int 20 ; Value.Int 30 |];
+    inputs = Value.[
+      (Array.map ~f:(fun (a,b,c,d) -> Array (a,b,c,d))
+                 [| (Type.INT, Type.INT,
+                     [ (Int 3, Int 10) ; (Int 3, Int 30) ; (Int 2, Int 20) ; (Int 1, Int 10) ],
+                     Int 1)
+                  ; (Type.INT, Type.INT,
+                     [ (Int 2, Int 20) ; (Int 1, Int 1024) ],
+                     Int 0)
+                  ; (Type.INT, Type.INT,
+                     [ (Int 0 , Int 0)],
+                     Int 30) |]);
+      [| Int 3 ; Int 2 ; Int 3 |] ];
+    outputs = Value.[| Int 10 ; Int 20 ; Int 30 |];
     constants = []
   } in Alcotest.(check string) "identical" "(select a k)" result.string
 
@@ -84,67 +84,111 @@ let store_a_k_v__empty () =
 let open Synthesizer in
 let result = solve ~config:{ Config.default with logic = Logic.of_string "ALIA" } {
   arg_names = [ "a" ; "k" ; "v"];
-  inputs = [ (Array.map ~f:(fun (a,b,c,d) -> Value.Array (a,b,c,d))
-                        [| (Type.INT, Type.INT, [], Value.Int 1)
-                         ; (Type.INT, Type.INT, [], Value.Int 0)
-                         ; (Type.INT, Type.INT, [], Value.Int 30) |])
-           ; [| Value.Int 1 ; Value.Int 2 ; Value.Int 3 |]
-           ; [| Value.Int 20 ; Value.Int 40 ; Value.Int 6 |] ];
-  outputs = [| Value.Array (Type.INT, Type.INT, [ (Value.Int 1, Value.Int 20) ], Value.Int 1)
-             ; Value.Array (Type.INT, Type.INT, [ (Value.Int 2, Value.Int 40) ], Value.Int 0)
-             ; Value.Array (Type.INT, Type.INT, [ (Value.Int 3, Value.Int 6) ], Value.Int 30) |];
+  inputs = Value.[
+    (Array.map ~f:(fun (a,b,c,d) -> Array (a,b,c,d))
+               [| (Type.INT, Type.INT, [], Int 1)
+                ; (Type.INT, Type.INT, [], Int 0)
+                ; (Type.INT, Type.INT, [], Int 30) |]);
+    [| Int 1 ; Int 2 ; Int 3 |];
+    [| Int 20 ; Int 40 ; Int 6 |] ];
+  outputs = Value.[| Array (Type.INT, Type.INT, [ (Int 1, Int 20) ], Int 1)
+                   ; Array (Type.INT, Type.INT, [ (Int 2, Int 40) ], Int 0)
+                   ; Array (Type.INT, Type.INT, [ (Int 3, Int 6) ], Int 30) |];
   constants = []
 } in Alcotest.(check string) "identical" "(store a k v)" result.string
 
 let store_a_k_v__nonempty () =
   let result = solve ~config:{ Config.default with logic = Logic.of_string "ALIA" } {
     arg_names = [ "a" ; "k" ; "v"];
-    inputs = [ (Array.map ~f:(fun (a,b,c,d) -> Value.Array (a,b,c,d))
-                          [| (Type.INT, Type.INT, [ (Value.Int 3, Value.Int 20) ], Value.Int 1)
-                           ; (Type.INT, Type.INT, [ (Value.Int 6, Value.Int 20) ], Value.Int 0)
-                           ; (Type.INT, Type.INT, [ (Value.Int 1, Value.Int 20) ], Value.Int 30) |])
-             ; [| Value.Int 1 ; Value.Int 2 ; Value.Int 3 |]
-             ; [| Value.Int 20 ; Value.Int 40 ; Value.Int 6 |] ];
-    outputs = [| Value.Array (Type.INT, Type.INT,
-                              [ (Value.Int 1, Value.Int 20) ; (Value.Int 3, Value.Int 20) ],
-                              Value.Int 1)
-               ; Value.Array (Type.INT, Type.INT,
-                              [ (Value.Int 2, Value.Int 40) ; (Value.Int 6, Value.Int 20) ],
-                              Value.Int 0)
-               ; Value.Array (Type.INT, Type.INT,
-                              [ (Value.Int 3, Value.Int 6) ; (Value.Int 1, Value.Int 20) ],
-                              Value.Int 30) |];
+    inputs = Value.[
+      (Array.map ~f:(fun (a,b,c,d) -> Array (a,b,c,d))
+                 [| (Type.INT, Type.INT, [ (Int 3, Int 20) ], Int 1)
+                  ; (Type.INT, Type.INT, [ (Int 6, Int 20) ], Int 0)
+                  ; (Type.INT, Type.INT, [ (Int 1, Int 20) ], Int 30) |]);
+      [| Int 1 ; Int 2 ; Int 3 |];
+      [| Int 20 ; Int 40 ; Int 6 |] ];
+    outputs = Value.[| Array (Type.INT, Type.INT,
+                              [ (Int 1, Int 20) ; (Int 3, Int 20) ],
+                              Int 1)
+                     ; Array (Type.INT, Type.INT,
+                              [ (Int 2, Int 40) ; (Int 6, Int 20) ],
+                              Int 0)
+                     ; Array (Type.INT, Type.INT,
+                              [ (Int 3, Int 6) ; (Int 1, Int 20) ],
+                              Int 30) |];
     constants = []
   } in Alcotest.(check string) "identical" "(store a k v)" result.string
 
 let store_a_k_v__with_duplicates () =
   let result = solve ~config:{ Config.default with logic = Logic.of_string "ALIA" } {
     arg_names = [ "a" ; "k" ; "v"];
-    inputs = [ (Array.map ~f:(fun (a,b,c,d) -> Value.Array (a,b,c,d))
-                          [| (Type.INT, Type.INT, [ (Value.Int 3, Value.Int 20) ], Value.Int 1)
-                           ; (Type.INT, Type.INT, [ (Value.Int 6, Value.Int 20) ], Value.Int 0)
-                           ; (Type.INT, Type.INT, [ (Value.Int 1, Value.Int 20) ], Value.Int 30) |])
-             ; [| Value.Int 3 ; Value.Int 2 ; Value.Int 3 |]
-             ; [| Value.Int 10 ; Value.Int 40 ; Value.Int 6 |] ];
-    outputs = [| Value.Array (Type.INT, Type.INT,
-                              [ (Value.Int 3, Value.Int 10) ; (Value.Int 3, Value.Int 20) ],
-                              Value.Int 1)
-               ; Value.Array (Type.INT, Type.INT,
-                              [ (Value.Int 2, Value.Int 40) ; (Value.Int 6, Value.Int 20) ],
-                              Value.Int 0)
-               ; Value.Array (Type.INT, Type.INT,
-                              [ (Value.Int 3 , Value.Int 6) ; (Value.Int 1, Value.Int 20) ],
-                              Value.Int 30) |];
+    inputs = Value.[
+      (Array.map ~f:(fun (a,b,c,d) -> Array (a,b,c,d))
+                 [| (Type.INT, Type.INT, [ (Int 3, Int 20) ], Int 1)
+                  ; (Type.INT, Type.INT, [ (Int 6, Int 20) ], Int 0)
+                  ; (Type.INT, Type.INT, [ (Int 1, Int 20) ], Int 30) |]);
+      [| Int 3 ; Int 2 ; Int 3 |];
+      [| Int 10 ; Int 40 ; Int 6 |] ];
+    outputs = Value.[| Array (Type.INT, Type.INT,
+                              [ (Int 3, Int 10) ; (Int 3, Int 20) ],
+                              Int 1)
+                     ; Array (Type.INT, Type.INT,
+                              [ (Int 2, Int 40) ; (Int 6, Int 20) ],
+                              Int 0)
+                     ; Array (Type.INT, Type.INT,
+                              [ (Int 3 , Int 6) ; (Int 1, Int 20) ],
+                              Int 30) |];
     constants = []
   } in Alcotest.(check string) "identical" "(store a k v)" result.string
 
+let ge_y_len_x () =
+  let open Synthesizer in
+  let result = solve ~config:{ Config.default with logic = Logic.of_string "ALL" } {
+    arg_names = [ "x" ; "y" ];
+    inputs = Value.[
+      Array.map ~f:(fun l -> List (Type.INT, (List.map l ~f:(fun i -> Int i))))
+                [| [1; (-1); 2]
+                 ; [1; (-1); 2]
+                 ; [1; (-1); 2]
+                 ; [3]
+                 ; [1]
+                 ; [2] |];
+      Array.map ~f:(fun i -> Int i)
+                [| 2; 3; 4; 5; 0; (-1) |];
+    ];
+    outputs = Array.map ~f:(fun b -> Value.Bool b)
+                        [| false; true; true; true; false; false |];
+    constants = []
+  } in Alcotest.(check string) "identical" "(>= y (len x))" result.string
+
+let all_mapR_ge_l_0 () =
+  let open Synthesizer in
+  let result = solve ~config:{ Config.default with logic = Logic.of_string "ALL" } {
+    arg_names = [ "l" ];
+    inputs = Value.[
+      Array.map ~f:(fun l -> List (Type.INT, (List.map l ~f:(fun i -> Int i))))
+                [| [11; (-1); 0]
+                 ; [7; 3; 1]
+                 ; [2; (-3)]
+                 ; [2]
+                 ; [0; 1; 3; 6]
+                 ; [(-1); 1; 9]
+                 ; [] |]
+    ];
+    outputs = Array.map ~f:(fun b -> Value.Bool b)
+                        [| false; true; false; true; true; false; true |];
+    constants = []
+  } in Alcotest.(check string) "identical" "(all (map-fixR-int-geq l 0))" result.string
+
 let all = [
-  "(+ x y)",                         `Quick, y_PLUS_x ;
-  "(>= (+ x z) y)",                  `Quick, y_MINUS_z_LE_x ;
-  "(not (= (= w x) (= y z)))",       `Quick, y_MINUS_x_MINUS_z_LE_x ;
+  "(+ x y)",                         `Quick, plus_x_y ;
+  "(>= (+ x z) y)",                  `Quick, ge_plus_x_z_y ;
+  "(not (= (= w x) (= y z)))",       `Quick, not_or_eq_w_x_eq_y_z ;
   "(select a k)",                    `Quick, select_a_k ;
   "(store a k v) ; empty",           `Quick, store_a_k_v__empty ;
   "(store a k v) ; non-empty",       `Quick, store_a_k_v__nonempty ;
   "(select a k)  ; with duplicates", `Quick, select_a_k__with_duplicates ;
   "(store a k v) ; with duplicates", `Quick, store_a_k_v__with_duplicates ;
+  "(>= y (len x))",                  `Quick, ge_y_len_x ;
+  "(all (map-fixR-int-geq l 0))",    `Quick, all_mapR_ge_l_0 ;
 ]

--- a/test/Test_Unification.ml
+++ b/test/Test_Unification.ml
@@ -14,35 +14,35 @@ let monomorphic () =
   let bindings = Unification.of_types_exn domain1 domain2 in
   let bindings_correct = [] in
   let res = are_bindings_equal bindings bindings_correct
-in Alcotest.(check bool) "identical" true res
+   in Alcotest.(check bool) "identical" true res
 
 let without_dependencies () =
   let domain1 = [ ARRAY (TVAR "a", TVAR "b") ; INT ; STRING ] in
-  let domain2 = [ ARRAY(INT,BOOL) ; INT ; STRING ] in
+  let domain2 = [ ARRAY (INT,BOOL) ; INT ; STRING ] in
   let bindings = Unification.of_types_exn domain1 domain2 in
   let bindings_correct = [("a", INT); ("b", BOOL)] in
   let res = are_bindings_equal bindings bindings_correct
-in Alcotest.(check bool) "identical" true res
+   in Alcotest.(check bool) "identical" true res
 
 let with_dependencies () =
-  let domain1 = [ ARRAY (TVAR "a", TVAR "b") ; TVAR "a" ] in
-  let domain2 = [ ARRAY(STRING,INT) ; STRING ] in
+  let domain1 = [ ARRAY (TVAR "a", TVAR "b") ; LIST(TVAR "a") ] in
+  let domain2 = [ ARRAY (STRING,INT) ; LIST STRING ] in
   let bindings = Unification.of_types_exn domain1 domain2 in
   let correct_bindings = [("a", STRING) ; ("b", INT)] in
   let res = are_bindings_equal bindings correct_bindings
-in Alcotest.(check bool) "identical" true res
+   in Alcotest.(check bool) "identical" true res
 
 let indirect_circular () =
   let domain1 = [(TVAR "x") ; ARRAY(TVAR "x",INT)] in
   let domain2 = [(ARRAY(INT,INT)) ; ARRAY(INT,INT)] in
   let test () = ignore (Unification.of_types_exn domain1 domain2)
-in Alcotest.check_raises "cannot unify" (Unification_Exn "Circular dependency!") test
+   in Alcotest.check_raises "cannot unify" (Unification_Exn "Circular dependency!") test
 
 let direct_circular () =
-  let domain1 = [ ARRAY((ARRAY(INT,TVAR "a")) , TVAR "a") ] in
-  let domain2 = [ ARRAY((ARRAY(TVAR "b",TVAR "a")) , INT) ] in
+  let domain1 = [ ARRAY (ARRAY(INT,TVAR "a") , TVAR "a") ] in
+  let domain2 = [ ARRAY (ARRAY(TVAR "b",TVAR "a") , INT) ] in
   let test () = ignore (Unification.of_types_exn domain1 domain2)
-in Alcotest.check_raises "cannot unify" (Unification_Exn "Circular dependency!") test
+   in Alcotest.check_raises "cannot unify" (Unification_Exn "Circular dependency!") test
 
 let substitution () =
   let env = [("a",STRING) ; ("b",INT)] in
@@ -51,7 +51,7 @@ let substitution () =
   let res = match Unification.substitute env codomain with
             | Some res -> equal res resolved_codomain
             | None -> false
-in Alcotest.(check bool) "correct application of env" true res
+   in Alcotest.(check bool) "correct application of env" true res
 
 let incomplete_substitution () =
   let env = [("a",INT)] in
@@ -60,7 +60,7 @@ let incomplete_substitution () =
   let res = match Unification.substitute env codomain with
             | Some res -> equal res resolved_codomain
             | None -> false
-in Alcotest.(check bool) "incorrect application of env" false res
+   in Alcotest.(check bool) "incorrect application of env" false res
 
 let all = [
   "Unif. of monomorphic types",   `Quick, monomorphic ;


### PR DESCRIPTION
The aim of this feature is to help the synthesizer generate more powerful expressions on list types, in order to simulate reasoning with quantifiers.

First, TypedList is created so that the synthesizer can better compose with components that only deal with lists of a particular type, or lists with type variables. 

Further, a component map-transformer, originally dubbed 'meta-component', is implemented to lift any existing primitive component to its list equivalent, by acting like a map on all the elements. This enables us to fully leverage existing components to reason with lists.

Special boolean list components like "forall" and "exist" are also implemented to bring the list expressions back into the primitive space by transforming a bool list into a bool, so that the list components can be ultimately incorporated into the predicate. 

